### PR TITLE
Switching from npm install to npm ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ env.cache-name }}-
       - name: Install npm packages
-        run: npm install
+        run: npm ci
       - name: Install & Cache apt packages
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
According to the NPM documentation, for automated environments, we should use `npm ci` over `npm install` as `ci` does a clean install, which doesn't try to upgrade any packages. It strictly follows the `package.json` & `package-lock.json`.