### PR TITLE
Making the extension install the dependencies on first activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "super-code-generator",
-  "version": "4.0.0",
+  "version": "4.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "super-code-generator",
-      "version": "4.0.0",
+      "version": "4.19.0",
       "dependencies": {
         "change-case": "^4.1.2",
         "esbuild": "^0.12.29",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Super Code Generator",
   "description": "A powerful, fast, and scalable code generator that saves you time",
   "publisher": "tenjojeremy",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -44,7 +44,8 @@
   },
   "activationEvents": [
     "onCommand:superCodeGenerator.generateCode",
-    "onCommand:superCodeGenerator.generateCodeInFolder"
+    "onCommand:superCodeGenerator.generateCodeInFolder",
+    "onStartupFinished"
   ],
   "contributes": {
     "configuration": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,12 +52,33 @@ export type SuperCodeGeneratorUserConfigSchema = {
 
 const extensionName = 'superCodeGenerator'
 
+
+function firstTimeActivation(context: vscode.ExtensionContext) {
+  const version =  context.extension.packageJSON.version ?? "1.0.0";
+  const previousVersion = context.globalState.get(context.extension.id);
+  if (previousVersion === version) return;
+
+  // Do something on first activation
+  const terminal = vscode.window.createTerminal({
+    name: 'Super Code Generator - Install Dependencies',
+    hideFromUser: false,
+    isTransient: true,
+    cwd: context.extensionPath,
+  });
+  terminal.sendText('npm ci --omit=dev');
+  terminal.show();
+  terminal.dispose();
+  console.log(`${extensionName} - Successfully installed dependencies!`)
+  context.globalState.update(context.extension.id, version);
+}
+
 /**
  * @param {vscode.ExtensionContext} context
  * {@Link https://code.visualstudio.com/api/references/vscode-api#ExtensionContext|ExtensionContext API}
  */
 export function activate(context: vscode.ExtensionContext) {
   console.log(`${extensionName} activated!`)
+  firstTimeActivation(context);
 
   // Register the generateCode command
   context.subscriptions.push(


### PR DESCRIPTION
This PR adds `onStartupFinished` to the `activationEvents,` allowing it to get the extension's current version and then compare it to a stored value. If there is a mismatch, it will install the `dependencies` from the package.json file, fixing the issue where the extension would not work on other OSes as it is typically built on MacOS.