### PR TITLE
Changing Command Used by Auto Dependency Installer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function firstTimeActivation(context: vscode.ExtensionContext) {
     isTransient: true,
     cwd: context.extensionPath,
   });
-  terminal.sendText('npm ci --omit=dev');
+  terminal.sendText('npm i --omit=dev');
   terminal.show();
   terminal.dispose();
   console.log(`${extensionName} - Successfully installed dependencies!`)


### PR DESCRIPTION
After downloading the extension, I checked the files, and we cannot use `npm ci` as the package-lock.json must be shipped with the code for the clean install to work. However, that is not the case, so I switched to using the command `npm i`