### PR TITLE
Adding Install Dependencies Command, and fixing the installer

### DIFF
--- a/example/app/.vscode/settings.json
+++ b/example/app/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "superCodeGenerator.schemaFilePath": "superCodeGen.schema.ts",
-  "superCodeGenerator.prettierConfigFilePath": ".prettierrc.js"
+  "superCodeGenerator.prettierConfigFilePath": ".prettierrc.js",
+  "superCodeGenerator.verbose": true
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "activationEvents": [
     "onCommand:superCodeGenerator.generateCode",
     "onCommand:superCodeGenerator.generateCodeInFolder",
+    "onCommand:superCodeGenerator.installDependencies",
     "onStartupFinished"
   ],
   "contributes": {
@@ -60,6 +61,16 @@
           "type": "string",
           "default": ".prettierrc.js",
           "description": "Prettier config file path (Optional)"
+        },
+        "superCodeGenerator.verbose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Verbose mode, defaults to false (Optional)"
+        },
+        "superCodeGenerator.useDependencyAutoInstaller": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use dependency auto installer, defaults to true (Optional, only needed on Linux & Windows)"
         }
       }
     },
@@ -71,6 +82,10 @@
       {
         "command": "superCodeGenerator.generateCodeInFolder",
         "title": "Super Code Gen: Generate Code in folder"
+      },
+      {
+        "command": "superCodeGenerator.installDependencies",
+        "title": "Super Code Gen: Install dependencies"
       }
     ],
     "menus": {

--- a/src/commands/installDependencies/index.ts
+++ b/src/commands/installDependencies/index.ts
@@ -1,0 +1,31 @@
+import vscode from "vscode"
+import { SuperCodeGeneratorSettingsSchema } from "../..";
+
+export function installDependencies(context: vscode.ExtensionContext, verbose?: boolean) {
+    if(verbose === undefined) {
+        // load the user config
+        const userConfig = context.workspaceState.get(`${context.extension.id}.extensionSettings`) as SuperCodeGeneratorSettingsSchema;
+        verbose = userConfig.verbose
+    }
+
+    // we add this event listener so that we can run the command after the terminal is created
+    const onTerminalOpenListener: vscode.Disposable = vscode.window.onDidOpenTerminal((_term) => {
+        if(_term.name === 'Super Code Generator - Install Dependencies') {
+            _term.sendText("npm ci --omit=dev;exit");
+            if(verbose)
+                vscode.window.showInformationMessage('Successfully installed dependencies');
+            // dispose the event listener
+            onTerminalOpenListener.dispose();
+        }
+    })
+
+    const terminal = vscode.window.createTerminal({
+        name: 'Super Code Generator - Install Dependencies',
+        // hide the terminal from the user if the user has verbose disabled
+        hideFromUser: !verbose,
+        isTransient: true,
+        cwd: context.extensionPath,
+    })
+    // don't take focus from the user
+    terminal.show(true);
+}

--- a/src/commands/installDependencies/index.ts
+++ b/src/commands/installDependencies/index.ts
@@ -3,7 +3,7 @@ import { SuperCodeGeneratorSettingsSchema } from "../..";
 
 export function installDependencies(context: vscode.ExtensionContext, verbose?: boolean) {
     if(verbose === undefined) {
-        // load the user config
+        // get the extension settings from the workspace state
         const userConfig = context.workspaceState.get(`${context.extension.id}.extensionSettings`) as SuperCodeGeneratorSettingsSchema;
         verbose = userConfig.verbose
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,8 +105,8 @@ export function activate(context: vscode.ExtensionContext) {
   
   // check if the user has enabled verbose mode
   const extensionSettings: SuperCodeGeneratorSettingsSchema = {
-    verbose: extensionConfig.get('verbose'),
-    useDependencyAutoInstaller: extensionConfig.get('useDependencyAutoInstaller'),
+    verbose: extensionConfig.get('verbose') || false,
+    useDependencyAutoInstaller: extensionConfig.get('useDependencyAutoInstaller') || true,
   };
   
   // save the extension settings to the workspace state

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,12 +108,13 @@ export function activate(context: vscode.ExtensionContext) {
     verbose: extensionConfig.get('verbose'),
     useDependencyAutoInstaller: extensionConfig.get('useDependencyAutoInstaller'),
   };
+  
+  // save the extension settings to the workspace state
+  context.workspaceState.update(`${context.extension.id}.extensionSettings`, extensionSettings);
 
   if(extensionSettings.verbose) {
     vscode.window.showInformationMessage('Super Code Generator running in verbose mode');
   }
-  
-  context.workspaceState.update(`${context.extension.id}.extensionSettings`, extensionSettings);
 
   if(extensionSettings.useDependencyAutoInstaller)
     firstTimeActivation(context)


### PR DESCRIPTION
Initially, the terminal used by the dependency installer was disposed of before the command could be run. I switched to using the event listener for `onTerminalOpenListener` and the `exit` command. I also added two settings: one allowing the user to disable the Auto Dependency Installer and the second enabling verbose mode, which shows the installer terminal and sends more notifications to the user. 