### PR TITLE
Fixing Error with NPM Command When Installing dependencies automatically after Update

### DIFF
--- a/src/commands/installDependencies/index.ts
+++ b/src/commands/installDependencies/index.ts
@@ -11,7 +11,7 @@ export function installDependencies(context: vscode.ExtensionContext, verbose?: 
     // we add this event listener so that we can run the command after the terminal is created
     const onTerminalOpenListener: vscode.Disposable = vscode.window.onDidOpenTerminal((_term) => {
         if(_term.name === 'Super Code Generator - Install Dependencies') {
-            _term.sendText("npm ci --omit=dev;exit");
+            _term.sendText("npm i --omit=dev;exit");
             if(verbose)
                 vscode.window.showInformationMessage('Successfully installed dependencies');
             // dispose the event listener

--- a/src/common/generateCode/handlers/create.ts
+++ b/src/common/generateCode/handlers/create.ts
@@ -44,7 +44,7 @@ export default async function create(props: {
           folderPath: props.componentOutputPath,
           type: props.componentConfig.type,
           params: props.params,
-          workspacePath: vscode.workspace.workspaceFolders[0].uri.path,
+          workspacePath: vscode.workspace.workspaceFolders?.[0].uri.path,
         }
         let parentFolderName =
           file?.parentFolderName?.(fileProperties) || props.name || ''

--- a/src/common/generateCode/index.ts
+++ b/src/common/generateCode/index.ts
@@ -163,7 +163,7 @@ export default async function generateCode({ outputPath }: generateCodeProps) {
               outputPath: outputPath,
               componentName: componentNameTrimmed,
               params,
-              workspacePath: vscode.workspace.workspaceFolders[0].uri.path,
+              workspacePath: vscode.workspace.workspaceFolders?.[0].uri.path,
               helpers,
             })
           }

--- a/src/common/generateCode/index.ts
+++ b/src/common/generateCode/index.ts
@@ -158,12 +158,12 @@ export default async function generateCode({ outputPath }: generateCodeProps) {
             params,
           })
 
-          if (selectedComponentTypeConfig?.hooks?.onCreate) {
+          if (selectedComponentTypeConfig?.hooks?.onCreate && vscode.workspace.workspaceFolders !== undefined) {
             await selectedComponentTypeConfig?.hooks?.onCreate({
               outputPath: outputPath,
               componentName: componentNameTrimmed,
               params,
-              workspacePath: vscode.workspace.workspaceFolders?.[0].uri.path,
+              workspacePath: vscode.workspace.workspaceFolders[0].uri.path,
               helpers,
             })
           }


### PR DESCRIPTION
In this PR, I am switching the install command used by the extension from `npm ci --omit=dev` to `npm i --omit=dev`. The command currently has an issue with not installing the dependencies. The error logs from the command are:
```
npm error code EUSAGE
npm error
npm error The `npm ci` command can only install with an existing package-lock.json or
npm error npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
npm error later to generate a package-lock.json file, then try again.
```
To fix this, if we use the non-clean install command, it seems to work just fine.